### PR TITLE
Add Base62 Encoder

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 8.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 8.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/src/Serials/Common/Alphabets.cs
+++ b/src/Serials/Common/Alphabets.cs
@@ -1,16 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Serials.Common
+﻿namespace Serials.Common
 {
     internal static class Alphabets
     {
         public const string AlphaNumeric = Numbers + Letters;
+        public const string AlphaNumericPlusLowercase = Numbers + Letters + LettersLowercase;
         public const string Numbers = "0123456789";
         public const string Letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        public const string LettersLowercase = "abcdefghijklmnopqrstuvwxyz";
 
         public const string AlphaNumericRegularExpression = "^[a-zA-Z0-9]+$";
+        public const string AlphaNumericPlusLowercaseRegularExpression = "^[a-zA-Z0-9]+$";
         public const string LettersRegularExpression = "^[a-zA-Z]+$";
         public const string NumbersRegularExpression = "^[0-9]+$";
     }

--- a/src/Serials/Common/Base62Encoder.cs
+++ b/src/Serials/Common/Base62Encoder.cs
@@ -1,0 +1,9 @@
+﻿namespace Serials.Common
+{
+    public class Base62Encoder : EncoderBase
+    {
+        public Base62Encoder() : base(Alphabets.AlphaNumericPlusLowercase, new System.Text.RegularExpressions.Regex(Alphabets.AlphaNumericPlusLowercaseRegularExpression))
+        {
+        }
+    }
+}

--- a/src/Serials/Common/EncoderBase.cs
+++ b/src/Serials/Common/EncoderBase.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Serials.Common
 {
@@ -12,13 +9,16 @@ namespace Serials.Common
     {
         protected string Alphabet { get; private set; }
         protected Regex Validator { get; private set; }
-        private readonly int AlphabetLength;
+
+        readonly int _alphabetLength;
+        readonly bool _onlyUseUppercase;
 
         protected EncoderBase(string alphabet, Regex validator)
         {
             Alphabet = alphabet;
             Validator = validator;
-            AlphabetLength = Alphabet.Length;
+            _alphabetLength = Alphabet.Length;
+            _onlyUseUppercase = Alphabet == Alphabet.ToUpper();
         }
 
         public BigInteger Decode(string encoded)
@@ -26,13 +26,13 @@ namespace Serials.Common
             if (string.IsNullOrWhiteSpace(encoded))
                 throw new ArgumentException("Cannot be null or empty", nameof(encoded));
 
-            var upperInput = encoded.ToUpper();
+            var sanitizedInput = (_onlyUseUppercase) ? encoded.ToUpper() : encoded;
             BigInteger result = 0;
-            for (int i = upperInput.Length - 1, j = 0; i >= 0; i--, j++)
+            for (int i = sanitizedInput.Length - 1, j = 0; i >= 0; i--, j++)
             {
-                var c = upperInput[i];
+                var c = sanitizedInput[i];
                 var alphabetIndex = Alphabet.IndexOf(c);
-                var multiplier = BigInteger.Pow(AlphabetLength, j);
+                var multiplier = BigInteger.Pow(_alphabetLength, j);
                 result += (alphabetIndex * multiplier);
             }
             return result;
@@ -43,13 +43,13 @@ namespace Serials.Common
             if (string.IsNullOrWhiteSpace(encoded))
                 throw new ArgumentException("Cannot be null or empty", nameof(encoded));
 
-            var upperInput = encoded.ToUpper();
+            var sanitizedInput = (_onlyUseUppercase) ? encoded.ToUpper() : encoded;
             ulong result = 0;
-            for (int i = upperInput.Length - 1, j = 0; i >= 0; i--, j++)
+            for (int i = sanitizedInput.Length - 1, j = 0; i >= 0; i--, j++)
             {
-                var c = upperInput[i];
+                var c = sanitizedInput[i];
                 var alphabetIndex = (ulong)Alphabet.IndexOf(c);
-                var multiplier = (ulong)Math.Pow(AlphabetLength, j);
+                var multiplier = (ulong)Math.Pow(_alphabetLength, j);
                 result += alphabetIndex * multiplier;
             }
             return result;
@@ -64,9 +64,9 @@ namespace Serials.Common
             var result = new Stack<char>();
             while (currentVal != 0)
             {
-                var index = (int)(currentVal % AlphabetLength);
+                var index = (int)(currentVal % _alphabetLength);
                 result.Push(Alphabet[index]);
-                currentVal /= AlphabetLength;
+                currentVal /= _alphabetLength;
             }
 
             return new string(result.ToArray());
@@ -81,9 +81,9 @@ namespace Serials.Common
             var result = new Stack<char>();
             while (currentVal != 0)
             {
-                var index = (int)(currentVal % (ulong)AlphabetLength);
+                var index = (int)(currentVal % (ulong)_alphabetLength);
                 result.Push(Alphabet[index]);
-                currentVal /= (ulong)AlphabetLength;
+                currentVal /= (ulong)_alphabetLength;
             }
 
             return new string(result.ToArray());

--- a/src/Serials/Serials.csproj
+++ b/src/Serials/Serials.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>Jason Williams</Authors>
-    <Company></Company>
+    <Company>
+    </Company>
     <Description>A library of types created to generate and mutate alpha-numeric sequences like serial numbers, invoices numbers, and record keeping reference numbers.</Description>
     <Copyright>Jason Williams</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -14,9 +14,8 @@
     <FileVersion>1.3.0.0</FileVersion>
     <Version>1.3.0</Version>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile></DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
-
 </Project>

--- a/src/Serials/Serials.csproj
+++ b/src/Serials/Serials.csproj
@@ -9,7 +9,12 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/centrolutions/serials</PackageProjectUrl>
     <RepositoryUrl>https://github.com/centrolutions/serials</RepositoryUrl>
-    <PackageReleaseNotes>Added alternate encoders, minimum length, and prefixes.</PackageReleaseNotes>
+    <PackageReleaseNotes>Breaking changes:
+	Upgraded to netstandard2.1 from netstandard2.0. This package is not compatible with older, unsupported versions of .NET.
+	
+	Other changes:
+	Added new Base62 encoder as an option for encoding ulong and BigInteger values.
+	</PackageReleaseNotes>
     <AssemblyVersion>1.4.0.0</AssemblyVersion>
     <FileVersion>1.4.0.0</FileVersion>
     <Version>1.4.0</Version>

--- a/src/Serials/Serials.csproj
+++ b/src/Serials/Serials.csproj
@@ -10,9 +10,9 @@
     <PackageProjectUrl>https://github.com/centrolutions/serials</PackageProjectUrl>
     <RepositoryUrl>https://github.com/centrolutions/serials</RepositoryUrl>
     <PackageReleaseNotes>Added alternate encoders, minimum length, and prefixes.</PackageReleaseNotes>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
-    <Version>1.3.0</Version>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
+    <Version>1.4.0</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>

--- a/tests/SerialsTests/Common/Base10EncoderTests.cs
+++ b/tests/SerialsTests/Common/Base10EncoderTests.cs
@@ -1,8 +1,6 @@
 ﻿using Serials.Common;
 using System;
-using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 using Xunit;
 
 namespace SerialsTests.Common

--- a/tests/SerialsTests/Common/Base36EncoderTests.cs
+++ b/tests/SerialsTests/Common/Base36EncoderTests.cs
@@ -1,8 +1,6 @@
 ﻿using Serials.Common;
 using System;
-using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 using Xunit;
 
 namespace SerialsTests.Common
@@ -94,7 +92,7 @@ namespace SerialsTests.Common
             var expected = BigInteger.Parse("999349339222911192293394455594493392229339444955949119293848475439");
 
             var decoded = _sut.Decode("4BCN8OTY5FAA7CN4TSGTXJ93D0XLNDXFS24MOK9MZOV");
-            
+
             Assert.Equal(expected, decoded);
         }
 

--- a/tests/SerialsTests/Common/Base62EncoderTests.cs
+++ b/tests/SerialsTests/Common/Base62EncoderTests.cs
@@ -5,15 +5,17 @@ using Xunit;
 
 namespace SerialsTests.Common
 {
-    public class AlphabetEncoderTests
+    public class Base62EncoderTests
     {
-        private readonly AlphabetEncoder _sut = new AlphabetEncoder();
+        private readonly Base62Encoder _sut = new Base62Encoder();
 
         [Theory]
-        [InlineData("A", 0)]
-        [InlineData("B", 1)]
-        [InlineData("K", 10)]
-        [InlineData("Z", 25)]
+        [InlineData("0", 0)]
+        [InlineData("1", 1)]
+        [InlineData("A", 10)]
+        [InlineData("Z", 35)]
+        [InlineData("a", 36)]
+        [InlineData("z", 61)]
         public void Decode_ReturnsCorrectBigInteger_WhenPassedASingleCharacter(string input, ulong expected)
         {
             BigInteger result = _sut.Decode(input);
@@ -22,9 +24,9 @@ namespace SerialsTests.Common
         }
 
         [Theory]
-        [InlineData("AA", 0)]
-        [InlineData("BA", 26)]
-        [InlineData("ZABABB", 297052003)]
+        [InlineData("00", 0)]
+        [InlineData("1R", 89)]
+        [InlineData("j10J3", 665174629)]
         public void Decode_ReturnsCorrectBigInteger_WhenPassedMultipleCharacterString(string input, ulong expected)
         {
             BigInteger result = _sut.Decode(input);
@@ -33,12 +35,12 @@ namespace SerialsTests.Common
         }
 
         [Fact]
-        public void Decode_ReturnsCorrectBigInteger_RegardlessOfCapitalization()
+        public void Decode_ReturnsDifferentBigInteger_BecauseOfCapitalization()
         {
             BigInteger capitalResult = _sut.Decode("ABC");
             BigInteger lowerResult = _sut.Decode("abc");
 
-            Assert.Equal(capitalResult, lowerResult);
+            Assert.NotEqual(capitalResult, lowerResult);
         }
 
         [Theory]
@@ -51,10 +53,13 @@ namespace SerialsTests.Common
 
 
         [Theory]
-        [InlineData(25, "Z")]
-        [InlineData(0, "A")]
-        [InlineData(1, "B")]
-        public void Encode_ReturnsProperString_WhenPassedValueBelow26(ulong input, string expected)
+        [InlineData(35, "Z")]
+        [InlineData(10, "A")]
+        [InlineData(1, "1")]
+        [InlineData(0, "0")]
+        [InlineData(36, "a")]
+        [InlineData(61, "z")]
+        public void Encode_ReturnsProperString_WhenPassedValueBelow62(ulong input, string expected)
         {
             var bigInput = new BigInteger(input);
 
@@ -64,8 +69,8 @@ namespace SerialsTests.Common
         }
 
         [Theory]
-        [InlineData(26, "BA")]
-        [InlineData(665174629, "CDZPQDP")]
+        [InlineData(62, "10")]
+        [InlineData(665174629, "j10J3")]
         public void Encode_ReturnsEncodedString_WhenPassedLargerNumbers(ulong input, string expected)
         {
             var bigInput = new BigInteger(input);
@@ -82,7 +87,7 @@ namespace SerialsTests.Common
 
             var result = _sut.Encode(big);
 
-            Assert.Equal("IDURTFPLWMLOKNSQWSPJSUJARYERKCFWWDYKKESWNYVCCKC", result);
+            Assert.Equal("Tl378UIZHzrJsVeygqelLiLyJceGHOxAHG2P8", result);
         }
 
         [Fact]
@@ -90,16 +95,18 @@ namespace SerialsTests.Common
         {
             var expected = BigInteger.Parse("999349339222911192293394455594493392229339444955949119293848475439");
 
-            var decoded = _sut.Decode("IDURTFPLWMLOKNSQWSPJSUJARYERKCFWWDYKKESWNYVCCKD");
+            var decoded = _sut.Decode("Tl378UIZHzrJsVeygqelLiLyJceGHOxAHG2P9");
 
             Assert.Equal(expected, decoded);
         }
 
         [Theory]
-        [InlineData("A", 0)]
-        [InlineData("B", 1)]
-        [InlineData("K", 10)]
-        [InlineData("Z", 25)]
+        [InlineData("0", 0)]
+        [InlineData("1", 1)]
+        [InlineData("A", 10)]
+        [InlineData("Z", 35)]
+        [InlineData("a", 36)]
+        [InlineData("z", 61)]
         public void DecodeULong_ReturnsCorrectULong_WhenPassedASingleCharacter(string input, ulong expected)
         {
             BigInteger result = _sut.DecodeULong(input);
@@ -108,9 +115,9 @@ namespace SerialsTests.Common
         }
 
         [Theory]
-        [InlineData("AA", 0)]
-        [InlineData("BA", 26)]
-        [InlineData("ZABABB", 297052003)]
+        [InlineData("00", 0)]
+        [InlineData("10", 62)]
+        [InlineData("j10J3", 665174629)]
         public void DecodeULong_ReturnsCorrectULong_WhenPassedMultipleCharacterString(string input, ulong expected)
         {
             BigInteger result = _sut.DecodeULong(input);
@@ -119,12 +126,12 @@ namespace SerialsTests.Common
         }
 
         [Fact]
-        public void DecodeULong_ReturnsCorrectULong_RegardlessOfCapitalization()
+        public void DecodeULong_ReturnsDifferentULong_BecauseOfCapitalization()
         {
             BigInteger capitalResult = _sut.DecodeULong("ABC");
             BigInteger lowerResult = _sut.DecodeULong("abc");
 
-            Assert.Equal(capitalResult, lowerResult);
+            Assert.NotEqual(capitalResult, lowerResult);
         }
 
         [Theory]
@@ -136,11 +143,13 @@ namespace SerialsTests.Common
         }
 
         [Theory]
-        [InlineData(25, "Z")]
-        [InlineData(10, "K")]
-        [InlineData(1, "B")]
-        [InlineData(0, "A")]
-        public void Encode_ReturnsProperString_WhenPassedLongValueBelow26(ulong input, string expected)
+        [InlineData(61, "z")]
+        [InlineData(36, "a")]
+        [InlineData(35, "Z")]
+        [InlineData(10, "A")]
+        [InlineData(1, "1")]
+        [InlineData(0, "0")]
+        public void Encode_ReturnsProperString_WhenPassedLongValueBelow36(ulong input, string expected)
         {
             var result = _sut.Encode(input);
 
@@ -148,8 +157,8 @@ namespace SerialsTests.Common
         }
 
         [Theory]
-        [InlineData(26, "BA")]
-        [InlineData(297052003, "ZABABB")]
+        [InlineData(62, "10")]
+        [InlineData(665174629, "j10J3")]
         public void Encode_ReturnsEncodedString_WhenPassedLargerLongNumbers(ulong input, string expected)
         {
             var result = _sut.Encode(input);

--- a/tests/SerialsTests/SerialsTests.csproj
+++ b/tests/SerialsTests/SerialsTests.csproj
@@ -4,13 +4,13 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/SerialsTests/SerialsTests.csproj
+++ b/tests/SerialsTests/SerialsTests.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -18,9 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serials\Serials.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
- Added base62 encoder
- Updated base encoder to figure out if it should UpperCase input or not so base62 works (which includes lower case alphabet)

Primarily added new encoder to give an option for sites that want to put encoded ids in URLs or other messages. Because of character confusion ('0' or 'O', 'l' or 'I') this is probably not a great encoding for printed serial numbers, but opens possibilities to use the library for electronic serial numbers.